### PR TITLE
Replace value.value with value.exchange for MX records before 1.0

### DIFF
--- a/tests/test_provider_octodns_rackspace.py
+++ b/tests/test_provider_octodns_rackspace.py
@@ -346,7 +346,7 @@ class TestRackspaceProvider(TestCase):
                         'type': 'MX',
                         'ttl': 300,
                         'value': {
-                            'value': 'mail1.example.com.',
+                            'exchange': 'mail1.example.com.',
                             'priority': 1,
                         }
                     }
@@ -357,7 +357,7 @@ class TestRackspaceProvider(TestCase):
                         'type': 'MX',
                         'ttl': 300,
                         'value': {
-                            'value': 'mail2.example.com.',
+                            'exchange': 'mail2.example.com.',
                             'priority': 2
                         }
                     }
@@ -719,7 +719,7 @@ class TestRackspaceProvider(TestCase):
                     "data": {
                         'type': 'MX',
                         'ttl': 300,
-                        'value': {u'priority': 50, u'value': 'mx.test.com.'}
+                        'value': {u'priority': 50, u'exchange': 'mx.test.com.'}
                     }
                 }
             ]


### PR DESCRIPTION
As per https://github.com/octodns/octodns/blob/e60390207a74a7fb9794ddb89943fa513729d8be/octodns/record/__init__.py#L1111
value.value will be unsupported as of octodns 1.0.