### PR TITLE
Explicit strict_supports in tests

### DIFF
--- a/tests/test_provider_octodns_rackspace.py
+++ b/tests/test_provider_octodns_rackspace.py
@@ -40,7 +40,7 @@ class TestRackspaceProvider(TestCase):
         with requests_mock() as mock:
             mock.post(ANY, status_code=200, text=AUTH_RESPONSE)
             self.provider = RackspaceProvider(
-                'identity', 'test', 'api-key', '0'
+                'identity', 'test', 'api-key', '0', strict_supports=False
             )
             self.assertTrue(mock.called_once)
 


### PR DESCRIPTION
As of https://github.com/octodns/octodns/pull/957 we'll need t be explicit in our tests around the expectations of `Provider.strict_supports`. This PR is in preparation of that change. 

/cc https://github.com/octodns/octodns/pull/957