### PR TITLE
Add timeout config parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Pinning specific versions or SHAs is recommended to avoid unplanned upgrades.
 
 ```
 # Start with the latest versions and don't just copy what's here
-octodns==0.9.14
+octodns==0.9.21
 octodns-rackspace==0.0.1
 ```
 
@@ -40,6 +40,8 @@ providers:
     username: env/RACKSPACE_USERNAME
     # The api key that grants access for that user (required)
     api_key: env/RACKSPACE_API_KEY
+    # The timeout in seconds for the API calls to Rackspace (optional)
+    timeout: 10
 ```
 
 ### Support Information

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ providers:
     username: env/RACKSPACE_USERNAME
     # The api key that grants access for that user (required)
     api_key: env/RACKSPACE_API_KEY
-    # The timeout in seconds for the API calls to Rackspace (optional)
-    timeout: 10
+    # The timeout in seconds for the API calls to Rackspace (optional, default 10)
+    timeout: 15
 ```
 
 ### Support Information

--- a/octodns_rackspace/__init__.py
+++ b/octodns_rackspace/__init__.py
@@ -118,9 +118,7 @@ class RackspaceProvider(BaseProvider):
         return resp
 
     def _request_for_url(self, method, url, data):
-        resp = self._sess.request(
-            method, url, json=data, timeout=self.timeout
-        )
+        resp = self._sess.request(method, url, json=data, timeout=self.timeout)
         self.log.debug('_request:   status=%d', resp.status_code)
         resp.raise_for_status()
         return resp
@@ -128,9 +126,7 @@ class RackspaceProvider(BaseProvider):
     def _paginated_request_for_url(self, method, url, data, pagination_key):
         acc = []
 
-        resp = self._sess.request(
-            method, url, json=data, timeout=self.timeout
-        )
+        resp = self._sess.request(method, url, json=data, timeout=self.timeout)
         self.log.debug('_request:   status=%d', resp.status_code)
         resp.raise_for_status()
         acc.extend(resp.json()[pagination_key])

--- a/octodns_rackspace/__init__.py
+++ b/octodns_rackspace/__init__.py
@@ -44,11 +44,20 @@ def unescape_semicolon(s):
 class RackspaceProvider(BaseProvider):
     SUPPORTS_GEO = False
     SUPPORTS_DYNAMIC = False
-    SUPPORTS = set(('A', 'AAAA', 'ALIAS', 'CNAME', 'MX', 'NS', 'PTR', 'SPF',
-                    'TXT'))
+    SUPPORTS = set(
+        ('A', 'AAAA', 'ALIAS', 'CNAME', 'MX', 'NS', 'PTR', 'SPF', 'TXT')
+    )
 
-    def __init__(self, id, username, api_key, ratelimit_delay=0.0, default_timeout=10, *args,
-                 **kwargs):
+    def __init__(
+        self,
+        id,
+        username,
+        api_key,
+        ratelimit_delay=0.0,
+        default_timeout=10,
+        *args,
+        **kwargs,
+    ):
         self.log = logging.getLogger(f'RackspaceProvider[{id}]')
         super().__init__(id, *args, **kwargs)
 
@@ -109,7 +118,9 @@ class RackspaceProvider(BaseProvider):
         return resp
 
     def _request_for_url(self, method, url, data):
-        resp = self._sess.request(method, url, json=data, timeout=self.default_timeout)
+        resp = self._sess.request(
+            method, url, json=data, timeout=self.default_timeout
+        )
         self.log.debug('_request:   status=%d', resp.status_code)
         resp.raise_for_status()
         return resp
@@ -117,7 +128,9 @@ class RackspaceProvider(BaseProvider):
     def _paginated_request_for_url(self, method, url, data, pagination_key):
         acc = []
 
-        resp = self._sess.request(method, url, json=data, timeout=self.default_timeout)
+        resp = self._sess.request(
+            method, url, json=data, timeout=self.default_timeout
+        )
         self.log.debug('_request:   status=%d', resp.status_code)
         resp.raise_for_status()
         acc.extend(resp.json()[pagination_key])

--- a/octodns_rackspace/__init__.py
+++ b/octodns_rackspace/__init__.py
@@ -129,7 +129,7 @@ class RackspaceProvider(BaseProvider):
         acc = []
 
         resp = self._sess.request(
-            method, url, json=data, timeout=self.default_timeout
+            method, url, json=data, timeout=self.timeout
         )
         self.log.debug('_request:   status=%d', resp.status_code)
         resp.raise_for_status()

--- a/octodns_rackspace/__init__.py
+++ b/octodns_rackspace/__init__.py
@@ -54,7 +54,7 @@ class RackspaceProvider(BaseProvider):
         username,
         api_key,
         ratelimit_delay=0.0,
-        timeout=5,
+        timeout=10,
         *args,
         **kwargs,
     ):

--- a/octodns_rackspace/__init__.py
+++ b/octodns_rackspace/__init__.py
@@ -44,19 +44,18 @@ def unescape_semicolon(s):
 class RackspaceProvider(BaseProvider):
     SUPPORTS_GEO = False
     SUPPORTS_DYNAMIC = False
-    SUPPORTS = set(
-        ('A', 'AAAA', 'ALIAS', 'CNAME', 'MX', 'NS', 'PTR', 'SPF', 'TXT')
-    )
-    TIMEOUT = 5
+    SUPPORTS = set(('A', 'AAAA', 'ALIAS', 'CNAME', 'MX', 'NS', 'PTR', 'SPF',
+                    'TXT'))
 
-    def __init__(
-        self, id, username, api_key, ratelimit_delay=0.0, *args, **kwargs
-    ):
+    def __init__(self, id, username, api_key, ratelimit_delay=0.0, default_timeout=10, *args,
+                 **kwargs):
         self.log = logging.getLogger(f'RackspaceProvider[{id}]')
         super().__init__(id, *args, **kwargs)
 
         auth_token, dns_endpoint = self._get_auth_token(username, api_key)
         self.dns_endpoint = dns_endpoint
+
+        self.default_timeout = default_timeout
 
         self.ratelimit_delay = float(ratelimit_delay)
 
@@ -110,7 +109,7 @@ class RackspaceProvider(BaseProvider):
         return resp
 
     def _request_for_url(self, method, url, data):
-        resp = self._sess.request(method, url, json=data, timeout=self.TIMEOUT)
+        resp = self._sess.request(method, url, json=data, timeout=self.default_timeout)
         self.log.debug('_request:   status=%d', resp.status_code)
         resp.raise_for_status()
         return resp
@@ -118,7 +117,7 @@ class RackspaceProvider(BaseProvider):
     def _paginated_request_for_url(self, method, url, data, pagination_key):
         acc = []
 
-        resp = self._sess.request(method, url, json=data, timeout=self.TIMEOUT)
+        resp = self._sess.request(method, url, json=data, timeout=self.default_timeout)
         self.log.debug('_request:   status=%d', resp.status_code)
         resp.raise_for_status()
         acc.extend(resp.json()[pagination_key])

--- a/octodns_rackspace/__init__.py
+++ b/octodns_rackspace/__init__.py
@@ -64,7 +64,7 @@ class RackspaceProvider(BaseProvider):
         auth_token, dns_endpoint = self._get_auth_token(username, api_key)
         self.dns_endpoint = dns_endpoint
 
-        self.default_timeout = timeout
+        self.timeout = timeout
 
         self.ratelimit_delay = float(ratelimit_delay)
 

--- a/octodns_rackspace/__init__.py
+++ b/octodns_rackspace/__init__.py
@@ -54,7 +54,7 @@ class RackspaceProvider(BaseProvider):
         username,
         api_key,
         ratelimit_delay=0.0,
-        default_timeout=10,
+        timeout=5,
         *args,
         **kwargs,
     ):
@@ -64,7 +64,7 @@ class RackspaceProvider(BaseProvider):
         auth_token, dns_endpoint = self._get_auth_token(username, api_key)
         self.dns_endpoint = dns_endpoint
 
-        self.default_timeout = default_timeout
+        self.default_timeout = timeout
 
         self.ratelimit_delay = float(ratelimit_delay)
 

--- a/octodns_rackspace/__init__.py
+++ b/octodns_rackspace/__init__.py
@@ -119,7 +119,7 @@ class RackspaceProvider(BaseProvider):
 
     def _request_for_url(self, method, url, data):
         resp = self._sess.request(
-            method, url, json=data, timeout=self.default_timeout
+            method, url, json=data, timeout=self.timeout
         )
         self.log.debug('_request:   status=%d', resp.status_code)
         resp.raise_for_status()


### PR DESCRIPTION
Rackspace API might not be the fastest, and the timeout is set to 5 seconds, so if you make a big change, you might find an error like this [0].

We're busy doing some big DNS migrations with lots of changes, so I though it would be handy to have a parameter to control it.

Let me know if I've done anything weird or if there's additional pending work, as this is my first contribution to octodns.

[0]:
```python-traceback
Traceback (most recent call last):
  File "/Users/alvaro/Documents/repos/octodns/venv/bin/octodns-sync", line 8, in <module>
    sys.exit(main())
  File "/Users/alvaro/Documents/repos/octodns/venv/lib/python3.10/site-packages/octodns/cmds/sync.py", line 57, in main
    manager.sync(
  File "/Users/alvaro/Documents/repos/octodns/venv/lib/python3.10/site-packages/octodns/manager.py", line 653, in sync
    total_changes += target.apply(plan)
  File "/Users/alvaro/Documents/repos/octodns/venv/lib/python3.10/site-packages/octodns/provider/base.py", line 245, in apply
    self._apply(plan)
  File "/Users/alvaro/Documents/repos/octodns/venv/lib/python3.10/site-packages/octodns_rackspace/__init__.py", line 356, in _apply
    self._delete(f'domains/{domain_id}/records?{params}')
  File "/Users/alvaro/Documents/repos/octodns/venv/lib/python3.10/site-packages/octodns_rackspace/__init__.py", line 125, in _delete
    return self._request('DELETE', path, data=data)
  File "/Users/alvaro/Documents/repos/octodns/venv/lib/python3.10/site-packages/octodns_rackspace/__init__.py", line 90, in _request
    resp = self._request_for_url(method, url, data)
  File "/Users/alvaro/Documents/repos/octodns/venv/lib/python3.10/site-packages/octodns_rackspace/__init__.py", line 95, in _request_for_url
    resp = self._sess.request(method, url, json=data, timeout=self.TIMEOUT)
  File "/Users/alvaro/Documents/repos/octodns/venv/lib/python3.10/site-packages/requests/sessions.py", line 587, in request
    resp = self.send(prep, **send_kwargs)
  File "/Users/alvaro/Documents/repos/octodns/venv/lib/python3.10/site-packages/requests/sessions.py", line 701, in send
    r = adapter.send(request, **kwargs)
  File "/Users/alvaro/Documents/repos/octodns/venv/lib/python3.10/site-packages/requests/adapters.py", line 532, in send
    raise ReadTimeout(e, request=request)
requests.exceptions.ReadTimeout: HTTPSConnectionPool(host='lon.dns.api.rackspacecloud.com', port=443): Read timed out. (read timeout=5)
```