### PR TITLE
Add __version__, deprecated __VERSION__

### DIFF
--- a/octodns_rackspace/__init__.py
+++ b/octodns_rackspace/__init__.py
@@ -12,7 +12,8 @@ from octodns import __VERSION__ as octodns_version
 from octodns.provider.base import BaseProvider
 from octodns.record import Record
 
-__VERSION__ = '0.0.1'
+# TODO: remove __VERSION__ with the next major version release
+__version__ = __VERSION__ = '0.0.1'
 
 
 def _value_keyer(v):

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
-from os import environ
-from subprocess import CalledProcessError, check_output
+#!/usr/bin/env python
 
 from setuptools import find_packages, setup
 
@@ -12,23 +11,11 @@ def descriptions():
 
 
 def version():
-    version = 'unknown'
     with open('octodns_rackspace/__init__.py') as fh:
         for line in fh:
-            if line.startswith('__VERSION__'):
-                version = line.split("'")[1]
-                break
-
-    # pep440 style public & local version numbers
-    if environ.get('OCTODNS_RELEASE', False):
-        # public
-        return version
-    try:
-        sha = check_output(['git', 'rev-parse', 'HEAD']).decode('utf-8')[:8]
-    except (CalledProcessError, FileNotFoundError):
-        sha = 'unknown'
-    # local
-    return f'{version}+{sha}'
+            if line.startswith('__version__'):
+                return line.split("'")[1]
+    return 'unknown'
 
 
 description, long_description = descriptions()


### PR DESCRIPTION
add __version__ which in my research/testing for #1096 I ran into as being a
(more) standard/recommended name for the version, per pep8.

/cc https://peps.python.org/pep-0008/#module-level-dunder-names which mentions version
/cc https://github.com/octodns/octodns/pull/1099
