### PR TITLE
Version 1.0.0 version bump & changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v1.0.0 - 2024-??-?? - ???
+# v1.0.0 - 2025-05-04 - Long overdue 1.0
 
 ### Notedworthy Changes:
 

--- a/octodns_rackspace/__init__.py
+++ b/octodns_rackspace/__init__.py
@@ -13,7 +13,7 @@ from octodns.provider.base import BaseProvider
 from octodns.record import Record
 
 # TODO: remove __VERSION__ with the next major version release
-__version__ = __VERSION__ = '0.0.1'
+__version__ = __VERSION__ = '1.0.0'
 
 
 def _value_keyer(v):


### PR DESCRIPTION
# v1.0.0 - 2025-05-04 - Long overdue 1.0

### Notedworthy Changes:

* `SPF` record support removed, records should be migrated to `TXT` before
  upgrading.
